### PR TITLE
Update Issue Templates & Priority Labels has been added

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,32 +1,39 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: bug
+about: Create a report to help us improve SmartCookieWeb
+title: [Bug]
+labels: P2: Medium priority, bug
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+<!-- Right after [Bug] you should add a simple title describing the bug, e.g. [Bug] The app has crashed. -->
 
-**To Reproduce**
+<!-- Please only add more than one topic to the issue if they are directly related. New issues must be created for each different topic. -->
+
+<!-- The comments between these brackets won't show up in the submitted issue (as you can see in the Preview). -->
+
+
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+### To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots**
-If applicable, add screenshots or a screen recording to help explain your problem.
+### Screenshots
+<!-- If applicable, add screenshots or a screen recording to help explain your problem. -->
 
-**Device (please complete the following information):**
- - Device: [e.g. Xiaomi Mi Mix 3]
- - OS: [e.g. Android 10.0]
- - Version [e.g. 5.0.0]
+### Device Info
+ - Device: [e.g. Xiaomi Redmi Note 9]
+ - OS: [e.g. MIUI 12 (Android 10.0)]
+ - App version: [e.g. v10.0.1]
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,29 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: enhancement
+title: [Feature]
+labels: P2: Medium priority, enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- Right after [Feature] you should add a simple title describing the feature request, e.g. [Feature] AD Block Extension. -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- Please only add more than one topic to the issue if they are directly related. New issues must be created for each different topic. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- The comments between these brackets won't show up in the submitted issue (as you can see in the Preview). -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+
+### Describe the feature you want
+<!-- A clear and concise description of what you wish should happen.
+Example: *I think it would be nice if you add feature X which makes Y possible.
+
+Optionally, also describe alternatives you've considered.
+Example: *Z is also a good alternative. Not as good as Y, but at least...* or *I considered Z, but that didn't turn out to be a good idea because...* -->
+
+### Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is.
+Example: I'm always frustrated when [...] -->
+
+### Additional context
+<!-- Add any other context, like screenshots, about the feature request here. -->


### PR DESCRIPTION
I made some simple changes to the issue templates and added the priority labels (#172), but I think they will have to be added manually.
Here is the information for each label:

| Label name | Description | Color |
| --- | --- | --- |
| P0: Very high priority | Needs to be fixed as soon as possible | #FF0000 |
| P1: High priority | Needs to be explored soon | #ff9900 |
| P2: Medium priority | Can be explored calmly | #ffdd77 |
| P3: Low priority | Can be explored later | #77ffff |
| P4: Very low priority | It's not important at the moment | #ddffff | 