### PR TITLE
Fixed an issue where issue templates don't appear

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Issue templates were not appearing on the web version of github. I think that this resolves this issue.
I've seen it [here](https://github.com/TeamNewPipe/NewPipe/blob/dev/.github/ISSUE_TEMPLATE/config.yml).