### PR TITLE
Fixed README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
  <a href='https://play.google.com/store/apps/details?id=com.cookiegames.smartcookie&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_gb/badges/static/images/badges/en_badge_web_generic.png' height="50"/></a> 
  <a href='https://f-droid.org/en/packages/com.cookiegames.smartcookie/'><img alt='Get it on F-Droid' src='https://gitlab.com/fdroid/artwork/-/raw/master/badge/get-it-on-en.png' height="50"/></a>
-<p align="center"><a href="https://github.com/CookieJarApps/SmartCookieWeb-beta"><b>Beta Releases</b></a> &bull; <a href="https://help.cookiejarapps.com"><b>FAQ</b></a> &bull; <a href="https://smartcookieweb.com"><b>Website</b></a> &bull; <a href="https://smartcookieweb.com/contributors.php"><b>Contributors</b></a></p>
+<p align="center"><a href="https://github.com/CookieJarApps/SmartCookieWeb-beta/releases"><b>Beta Releases</b></a> &bull; <a href="https://smartcookieweb.com/docs/intro"><b>Docs</b></a> &bull; <a href="https://smartcookieweb.com"><b>Website</b></a> &bull; <a href="https://smartcookieweb.com/contributors.php"><b>Contributors</b></a></p>
 <h4 align="center"><em>Important note: Google recently announced that embedded browser frameworks, or any browsers that fake their user agent will be banned from Google sign in starting January next year. Now, even if you change your user agent, Google logins redirected from other apps may not work. Turning off "Allow sites to open new windows" in Advanced settings and turning on "Remove identifying HTTP headers" in Privacy and Security Settings, as well as setting the user agent in General Settings to "Mobile" should solve the issue. </em></h4>
 
 ---
@@ -29,7 +29,7 @@
 
 Need help? Open an issue here, or:
 
-- Visit the [help page](https://smartcookieweb.com/help)
+- Visit the [Docs](https://smartcookieweb.com/docs/intro)
 - Email me at `support@cookiejarapps.com`
 - Join the [Telegram chat](https://t.me/scwgroup)
 - Join the [Matrix chat](https://matrix.to/#/#smartcookieweb:matrix.org)
@@ -55,7 +55,7 @@ Need help? Open an issue here, or:
 
 ## Contributing
 
-Contributions are greatly appreciated. Feel free to open an issue or pull request or [help translate](translate.cookiejarapps.com)
+Contributions are greatly appreciated. Feel free to open an issue or pull request. Read the [developer docs](https://smartcookieweb.com/docs/smartcookieweb/developer/index) or [help translate](translate.cookiejarapps.com)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 Need help? Open an issue here, or:
 
 - Visit the [Docs](https://smartcookieweb.com/docs/intro)
-- Email me at `support@cookiejarapps.com`
+- [Email me](mailto:support@cookiejarapps.com) at `support@cookiejarapps.com`
 - Join the [Telegram chat](https://t.me/scwgroup)
 - Join the [Matrix chat](https://matrix.to/#/#smartcookieweb:matrix.org)
 


### PR DESCRIPTION
Changes:
- Made the beta releases point at the release page
- Changed FAQs to docs (the original link (https://help.cookiejarapps.com) returned a redirection error)
- Also made the help page point at the docs (the original link (https://smartcookieweb.com/help) returned a 404)
- Added a clickable email link
- Added a link to the developer docs

Things that still need doing:
- Fixing contributors page (https://smartcookieweb.com/contributors.php) - returned 404 and I could find no replacement (lines 23 & 64)
- Fixing online services link (https://smartcookieweb.com/help/development/#web-services) (line 78)

Feel free to ignore this PR - just making you aware of the few dead links on the readme! I'm assuming this is a result of your new website - the help pages no longer exist and it doesn't look like you use php anymore :D 