### PR TITLE
Homepage search bar encodes special characters properly

### DIFF
--- a/app/src/main/html/homepage.html
+++ b/app/src/main/html/homepage.html
@@ -296,8 +296,9 @@ img {
 
     <script type="text/javascript">
         function search() {
-            if (document.getElementById("search_input").value != "") {
-                window.location.href = "${BASE_URL}" + document.getElementById("search_input").value;
+            const search_query = document.getElementById("search_input").value.trim();
+            if (search_query != "") {
+                window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replaceAll("%20", "+");
                 document.getElementById("search_input").value = "";
             }
             return false;

--- a/app/src/main/html/homepage.html
+++ b/app/src/main/html/homepage.html
@@ -257,14 +257,14 @@ img {
                 <h2 class="text">SmartCookieWeb</h2>
                 </br>
                 </br>
-                <form onsubmit="return search()" class="search_bar" id="search_bar" autocomplete="off">
-                    <button type="submit" id="search_submit" value="Search"><img alt="\" style="display: inline-block;" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMCAwaDI0djI0SDBWMHoiLz48cGF0aCBkPSJNMTUuNSAxNGgtLjc5bC0uMjgtLjI3YzEuMi0xLjQgMS44Mi0zLjMxIDEuNDgtNS4zNC0uNDctMi43OC0yLjc5LTUtNS41OS01LjM0LTQuMjMtLjUyLTcuNzkgMy4wNC03LjI3IDcuMjcuMzQgMi44IDIuNTYgNS4xMiA1LjM0IDUuNTkgMi4wMy4zNCAzLjk0LS4yOCA1LjM0LTEuNDhsLjI3LjI4di43OWw0LjI1IDQuMjVjLjQxLjQxIDEuMDguNDEgMS40OSAwIC40MS0uNDEuNDEtMS4wOCAwLTEuNDlMMTUuNSAxNHptLTYgMEM3LjAxIDE0IDUgMTEuOTkgNSA5LjVTNy4wMSA1IDkuNSA1IDE0IDcuMDEgMTQgOS41IDExLjk5IDE0IDkuNSAxNHoiLz48L3N2Zz4=" />
+                <div class="search_bar" id="search_bar" autocomplete="off">
+                    <button id="search_submit" value="Search"><img alt="\" style="display: inline-block;" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMCAwaDI0djI0SDBWMHoiLz48cGF0aCBkPSJNMTUuNSAxNGgtLjc5bC0uMjgtLjI3YzEuMi0xLjQgMS44Mi0zLjMxIDEuNDgtNS4zNC0uNDctMi43OC0yLjc5LTUtNS41OS01LjM0LTQuMjMtLjUyLTcuNzkgMy4wNC03LjI3IDcuMjcuMzQgMi44IDIuNTYgNS4xMiA1LjM0IDUuNTkgMi4wMy4zNCAzLjk0LS4yOCA1LjM0LTEuNDhsLjI3LjI4di43OWw0LjI1IDQuMjVjLjQxLjQxIDEuMDguNDEgMS40OSAwIC40MS0uNDEuNDEtMS4wOCAwLTEuNDlMMTUuNSAxNHptLTYgMEM3LjAxIDE0IDUgMTEuOTkgNSA5LjVTNy4wMSA1IDkuNSA1IDE0IDcuMDEgMTQgOS41IDExLjk5IDE0IDkuNSAxNHoiLz48L3N2Zz4=" />
                     </button>
                     
                     <span>
                         <input class="search" type="text" value="" id="search_input" placeholder="Search" style="background: url('${IMAGE}') no-repeat scroll 7px 7px;"/>
                     </span>
-                </form>
+                </div>
                 </br>
                 </br>
                 <div class="shortcuts" id="shortcuts">
@@ -296,13 +296,20 @@ img {
 
     <script type="text/javascript">
         function search() {
-            const search_query = document.getElementById("search_input").value.trim();
+            var search_query = document.getElementById("search_input").value.trim();
             if (search_query != "") {
-                window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replaceAll("%20", "+");
+                window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replace(/%20/g, "+");
                 document.getElementById("search_input").value = "";
             }
             return false;
         }
+
+        function enter(key) {
+            if (key.keyCode == 13) search()
+        }
+
+        document.querySelector("#search_submit").addEventListener("click", search);
+        document.querySelector("#search_input").addEventListener("keydown", function(key) {enter(key)});
 
         var endpoint = "${ENDPOINT}";
 		console.log(endpoint);

--- a/app/src/main/html/private.html
+++ b/app/src/main/html/private.html
@@ -227,7 +227,7 @@
         function search() {
             var search_query = document.getElementById("search_input").value.trim();
             if (search_query != "") {
-                window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replaceAll("%20", "+");
+                window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replace(/%20/g, "+");
                 document.getElementById("search_input").value = "";
             }
             return false;
@@ -237,8 +237,8 @@
             if (key.keyCode == 13) search()
         }
 
-        document.querySelector("#search_submit").addEventListener("click", search)
-        document.querySelector("#search_input").addEventListener("keydown", key => enter(key))
+        document.querySelector("#search_submit").addEventListener("click", search);
+        document.querySelector("#search_input").addEventListener("keydown", function(key) {enter(key)});
         
     </script>
 

--- a/app/src/main/html/private.html
+++ b/app/src/main/html/private.html
@@ -193,14 +193,14 @@
               <h2 id="title-pm">$title</h2><p id="desc-pm">$description</p>
                 </br>
                 </br>
-                <form onsubmit="return search()" class="search_bar" id="search_bar" autocomplete="off">
-                    <button type="submit" id="search_submit" value="Search"><img alt="\" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMCAwaDI0djI0SDBWMHoiLz48cGF0aCBkPSJNMTUuNSAxNGgtLjc5bC0uMjgtLjI3YzEuMi0xLjQgMS44Mi0zLjMxIDEuNDgtNS4zNC0uNDctMi43OC0yLjc5LTUtNS41OS01LjM0LTQuMjMtLjUyLTcuNzkgMy4wNC03LjI3IDcuMjcuMzQgMi44IDIuNTYgNS4xMiA1LjM0IDUuNTkgMi4wMy4zNCAzLjk0LS4yOCA1LjM0LTEuNDhsLjI3LjI4di43OWw0LjI1IDQuMjVjLjQxLjQxIDEuMDguNDEgMS40OSAwIC40MS0uNDEuNDEtMS4wOCAwLTEuNDlMMTUuNSAxNHptLTYgMEM3LjAxIDE0IDUgMTEuOTkgNSA5LjVTNy4wMSA1IDkuNSA1IDE0IDcuMDEgMTQgOS41IDExLjk5IDE0IDkuNSAxNHoiLz48L3N2Zz4=" />
+                <div class="search_bar" id="search_bar" autocomplete="off">
+                    <button id="search_submit" value="Search"><img alt="\" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJub25lIiBkPSJNMCAwaDI0djI0SDBWMHoiLz48cGF0aCBkPSJNMTUuNSAxNGgtLjc5bC0uMjgtLjI3YzEuMi0xLjQgMS44Mi0zLjMxIDEuNDgtNS4zNC0uNDctMi43OC0yLjc5LTUtNS41OS01LjM0LTQuMjMtLjUyLTcuNzkgMy4wNC03LjI3IDcuMjcuMzQgMi44IDIuNTYgNS4xMiA1LjM0IDUuNTkgMi4wMy4zNCAzLjk0LS4yOCA1LjM0LTEuNDhsLjI3LjI4di43OWw0LjI1IDQuMjVjLjQxLjQxIDEuMDguNDEgMS40OSAwIC40MS0uNDEuNDEtMS4wOCAwLTEuNDlMMTUuNSAxNHptLTYgMEM3LjAxIDE0IDUgMTEuOTkgNSA5LjVTNy4wMSA1IDkuNSA1IDE0IDcuMDEgMTQgOS41IDExLjk5IDE0IDkuNSAxNHoiLz48L3N2Zz4=" />
                     </button>
                     
                     <span>
                         <input class="search" type="text" value="" id="search_input" placeholder="Search" style="background: url('${IMAGE}') no-repeat scroll 7px 7px;"/>
                     </span>
-                </form>
+                </div>
                 </br>
                 </br>
                 <div class="shortcuts" id="shortcuts">
@@ -225,13 +225,20 @@
     </div>
     <script type="text/javascript">
         function search() {
-            const search_query = document.getElementById("search_input").value.trim();
+            var search_query = document.getElementById("search_input").value.trim();
             if (search_query != "") {
                 window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replaceAll("%20", "+");
                 document.getElementById("search_input").value = "";
             }
             return false;
         }
+
+        function enter(key) {
+            if (key.keyCode == 13) search()
+        }
+
+        document.querySelector("#search_submit").addEventListener("click", search)
+        document.querySelector("#search_input").addEventListener("keydown", key => enter(key))
         
     </script>
 

--- a/app/src/main/html/private.html
+++ b/app/src/main/html/private.html
@@ -225,8 +225,9 @@
     </div>
     <script type="text/javascript">
         function search() {
-            if (document.getElementById("search_input").value != "") {
-                window.location.href = "${BASE_URL}" + document.getElementById("search_input").value;
+            const search_query = document.getElementById("search_input").value.trim();
+            if (search_query != "") {
+                window.location.href = "${BASE_URL}" + encodeURIComponent(search_query).replaceAll("%20", "+");
                 document.getElementById("search_input").value = "";
             }
             return false;


### PR DESCRIPTION
This PR fixes a bug related to the home page's search bar.

The bug: When I type in certain special characters into the search bar, the search results don't match up with what I typed.

For example: 
* Type in `1+3` in the search bar, the result becomes `1 3`. The result should instead stay as `1+3` and Google should then calculate the answer.
* Type in `#anything` and it takes you to Google's homepage. It should instead show me search results related to the hashtag `#anything`.

The fix: 
* Used the [`encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) function to convert the special characters into their UTF-8 encoded escape sequences.
* Interestingly, that didn't work on it's own. With what I understand, the [html `<form>` causes some problems with the redirect](https://stackoverflow.com/a/21133810). So I've replaced it with a `<div>` and used an event based approach to detect the search submission. 

It now works as expected! 🍪